### PR TITLE
added: support for autoform 5.0

### DIFF
--- a/package.js
+++ b/package.js
@@ -1,15 +1,20 @@
 Package.describe({
   name: 'comerc:autoform-typeahead',
   summary: 'Custom "typeahead" input type for AutoForm',
-  version: '1.0.1',
+  version: '1.0.2',
   git: 'https://github.com/comerc/meteor-autoform-typeahead.git'
 });
 
 Package.onUse(function(api) {
   api.versionsFrom('1.0');
-  api.use('templating@1.0.0');
-  api.use('blaze@2.0.0');
-  api.use('aldeed:autoform@4.0.0');
+
+  api.use([
+    'templating',
+    'blaze',
+    'aldeed:autoform',
+    'comerc:bs-typeahead'
+  ]);
+
   api.addFiles([
     'autoform-typeahead.html',
     'autoform-typeahead.js',


### PR DESCRIPTION
Needed to upgrade my app to autoform 5.0.0 but typeahead was not satisfied so I cloned your repo and implement it as a local package. I removed the versioning and test it with my app. My app works as expected. You might want to upgrade also. :)
