### PR TITLE
Fix issue #8

### DIFF
--- a/autoform-typeahead.js
+++ b/autoform-typeahead.js
@@ -84,5 +84,5 @@ Template.afTypeahead.rendered = function () {
 };
 
 Template.afTypeahead.destroyed = function () {
-  $('.twitter-typeahead').typeahead('destroy');
+  this.$('.twitter-typeahead').typeahead('destroy');
 };


### PR DESCRIPTION
You should just destroy typehead on current input,,,
If you want to work with array you should notice that there is bug in aldeed/meteor-autoform package
try this one: https://github.com/aldeed/meteor-autoform/issues/840#issuecomment-171633116
